### PR TITLE
cache: configurable backends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
 
 after_success:
   - coveralls
-  
+
 branches:
   only:
     - master

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,8 +23,10 @@ def app(tmpdir):
     return application.TimeGate(config=dict(
         HOST='http://localhost',
         BASE_URI='http://www.example.com/',
-        CACHE_USE=True,
-        CACHE_FILE=tmpdir.mkdir('cache').strpath,
+        CACHE_BACKEND='werkzeug.contrib.cache:FileSystemCache',
+        CACHE_OPTIONS={
+            'cache_dir': tmpdir.mkdir('cache').strpath,
+        },
     ))
 
 

--- a/timegate/application.py
+++ b/timegate/application.py
@@ -108,7 +108,7 @@ class TimeGate(object):
         self.config.update(config or {})
         if cache:
             self.cache = cache
-        elif self.config['CACHE_USE']:
+        else:
             self._build_default_cache()
 
     @cached_property
@@ -143,10 +143,10 @@ class TimeGate(object):
     def _build_default_cache(self):
         """Build default cache object."""
         self.cache = Cache(
-            self.config['CACHE_FILE'],
-            self.config['CACHE_TOLERANCE'],
-            self.config['CACHE_EXP'],
-            self.config['CACHE_MAX_VALUES'],
+            self.config.get('CACHE_BACKEND',
+                            'werkzeug.contrib.cache.NullCache'),
+            cache_refresh_time=self.config.get('CACHE_REFRESH_TIME', 86400),
+            **self.config.get('CACHE_OPTIONS', {})
         )
 
     def __repr__(self):

--- a/timegate/conf/config.ini
+++ b/timegate/conf/config.ini
@@ -41,11 +41,9 @@ base_uri = http://www.example.com/
 
 [cache]
 
-# cache_activated
-# When true, the cache stores TimeMaps from API that allows batch (get_all_mementos) requests, except for requests with `Cache-Control: no-cache` header, which will always return fresh Mementos.
-# When false, no cache file will be created
-# Default true
-cache_activated = false
+# cache_backend
+# For disabling cache use werkzeug.contrib.cache.NullCache
+cache_backend = werkzeug.contrib.cache:FileSystemCache
 
 # cache_refresh_time
 # Time in seconds, for which it is assumed that a TimeMap didn't change. Any TimeGate request for a datetime past this period (or any TimeMap request past this period) will trigger a refresh of the cached value.
@@ -55,10 +53,10 @@ cache_refresh_time = 86400
 # cache_directory
 # Cache directory relative path for data files. Make sure that this directory is empty or else the cache will start deleting random files.
 # Default cache/
-cache_directory = cache
+cache_dir = cache
 
-# cache_max_values
+# threshold
 # Maximum number of stored TimeMaps in the cache.
 # Tweak this depending on how big your TimeMaps can become (number of elements and length of URIs)
 # Default 250
-cache_max_values = 250
+threshold = 250

--- a/timegate/config.py
+++ b/timegate/config.py
@@ -56,18 +56,30 @@ class Config(dict):
             self['USE_TIMEMAPS'] = False
 
         # Cache
-        # When False, all cache requests will be cache MISS
-        self['CACHE_USE'] = conf.getboolean('cache', 'cache_activated')
+        self['CACHE_BACKEND'] = conf.get('cache', 'cache_backend')
         # Time window in which the cache value is considered young
         # enough to be valid
-        self['CACHE_TOLERANCE'] = conf.getint('cache', 'cache_refresh_time')
-        # Cache files paths
-        self['CACHE_DIRECTORY'] = conf.get(
-            'cache', 'cache_directory').rstrip('/')
-        # Maximum number of TimeMaps stored in cache
-        self['CACHE_MAX_VALUES'] = conf.getint('cache', 'cache_max_values')
-        # Cache files paths
-        self['CACHE_FILE'] = self['CACHE_DIRECTORY']  # + '/cache_data'
+        self['CACHE_REFRESH_TIME'] = conf.getint('cache', 'cache_refresh_time')
+
+        options = {
+            'cache_backend': None,
+            'cache_refresh_time': None,
+            'default_timeout': 'getint',
+            'mode': 'getint',
+            'port': 'getint',
+            'threshold': 'getint',
+        }
+        self.setdefault('CACHE_OPTIONS', {})
+
+        for key in conf.options('cache'):
+            if key in options:
+                getter = options[key]
+                if getter:
+                    self['CACHE_OPTIONS'][key] = getattr(conf, getter)(
+                        'cache', key
+                    )
+            else:
+                self['CACHE_OPTIONS'][key] = conf.get('cache', key)
 
     def from_object(self, obj):
         """Update config with values from given object.


### PR DESCRIPTION
Please note that the cache configuration is not backward compatible!
## 
- Adds support for any Werkzeug (like) cache backend.  (closes #15)
- Adds new configuration option `CACHE_BACKEND`. All options in
  INI file `[cache]` section are passed to the cache constructor.

Signed-off-by: Jiri Kuncar jiri.kuncar@cern.ch
